### PR TITLE
Usar versao do OpenTK suportada no MacOS Monterey

### DIFF
--- a/CG_Biblioteca/CG_Biblioteca.csproj
+++ b/CG_Biblioteca/CG_Biblioteca.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
 <!-- MacOS
-  <PackageReference Include="OpenTK" Version="3.2.0"/>
+  <PackageReference Include="OpenTK" Version="3.3.2"/>
 -->    
 <!-- Windows
   <PackageReference Include="OpenTK.NetCore" Version="*" />

--- a/unidade_2/CG_N2/CG_N2.csproj
+++ b/unidade_2/CG_N2/CG_N2.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 <!-- MacOS
-  <PackageReference Include="OpenTK" Version="3.2.0"/>
+  <PackageReference Include="OpenTK" Version="3.3.2"/>
 -->    
 <!-- Windows
   <PackageReference Include="OpenTK.NetCore" Version="*" />


### PR DESCRIPTION
A [versão 3.3.2 do OpenTK](https://www.nuget.org/packages/OpenTK/3.3.2) conserta um problema que previne aplicações de funcionar corretamente no macOS Monterey.

Essa PR atualiza a versão utilizada pelos projetos na disciplina para a versão compatível mais próxima.